### PR TITLE
Allow to render diagrams from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ blockdiag {
 ```
 ````
 
+You can render diagram from file with `@from_file:` directive:
+
+````markdown
+```kroki-bpmn
+@from_file:path/to/diagram.bpmn
+```
+````
+
 ## See Also
 
 Diagram examples can be found [here](https://kroki.io/examples.html).


### PR DESCRIPTION
I want to render really big diagrams (BPMN, which is XML), so it's handy to put diagram code in separate file and link it from docs.