### PR TITLE
Use relative image path for downloaded diagrams

### DIFF
--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -83,7 +83,7 @@ class KrokiPlugin(BasePlugin):
         mkdocs_file = File(get_url, self._tmp_dir.name, self._output_dir, False)
         files.append(mkdocs_file)
 
-        return f'/{get_url}'
+        return f'./{get_url}'
 
     def _replace_kroki_block(self, match_obj, files, page):
         kroki_type = match_obj.group(1).lower()


### PR DESCRIPTION
Remove the / from _save_kroki_image_and_get_url so that generated mkdocs images can be served on non root domains or within Backstages techdocs. 

This more closely matches the previous behavior before [HttpMethod option #7](https://github.com/AVATEAM-IT-SYSTEMHAUS/mkdocs-kroki-plugin/pull/7/files#diff-cecde450a4758f3e7056729af40852b43ed972239549c439eec9278d30311fceL130)


