### PR TITLE
enable support for experimental diagramsnet in kroki

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ plugins:
 * `Enablebpmn` - Enable BPMN, default: True
 * `EnableExcalidraw` - Enable Excalidraw, default: True
 * `EnableMermaid` - Enable Mermaid, default: True
+* `EnableDiagramsnet` - Enable diagrams.net (draw.io), default: False
 * `HttpMethod` - Http method to use (`GET` or `POST`), default: `GET` (Note: you have to enable `DownloadImages` if you want to use `POST`!)
 * `DownloadImages` - Download diagrams from kroki as static assets instead of just creating kroki links, default: False
 * `DownloadDir` - The asset directory to place downloaded svg images in, default: images/kroki_generated

--- a/kroki/config.py
+++ b/kroki/config.py
@@ -44,7 +44,7 @@ class KrokiDiagramTypes():
     }
 
     kroki_diagramsnet = (
-        "diagramsnet": ["png", "svg"],
+        "diagramsnet": ["svg"],
     )
 
     def __init__(self, blockdiag_enabled, bpmn_enabled, excalidraw_enabled,

--- a/kroki/config.py
+++ b/kroki/config.py
@@ -37,7 +37,11 @@ class KrokiDiagramTypes():
         "mermaid",
     )
 
-    def __init__(self, blockdiag_enabled, bpmn_enabled, excalidraw_enabled, mermaid_enabled):
+    kroki_diagramsnet = (
+        "diagramsnet",
+    )
+
+    def __init__(self, blockdiag_enabled, bpmn_enabled, excalidraw_enabled, mermaid_enabled, diagramsnet_enabled):
         self.diagram_types = self.kroki_base
 
         if blockdiag_enabled:
@@ -48,6 +52,8 @@ class KrokiDiagramTypes():
             self.diagram_types += self.kroki_excalidraw
         if mermaid_enabled:
             self.diagram_types += self.kroki_mermaid
+        if diagramsnet_enabled:
+            self.diagram_types += self.kroki_diagramsnet
 
     def get_block_regex(self, fence_prefix):
         diagram_types_re = "|".join(self.diagram_types)

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -26,6 +26,7 @@ class KrokiPlugin(BasePlugin):
         ('Enablebpmn', config.config_options.Type(bool, default=True)),
         ('EnableExcalidraw', config.config_options.Type(bool, default=True)),
         ('EnableMermaid', config.config_options.Type(bool, default=True)),
+        ('EnableDiagramsnet', config.config_options.Type(bool, default=False)),
         ('HttpMethod', config.config_options.Type(str, default='GET')),
         ('DownloadImages', config.config_options.Type(bool, default=False)),
         ('EmbedImages', config.config_options.Type(bool, default=False)),
@@ -43,7 +44,8 @@ class KrokiPlugin(BasePlugin):
         self.diagram_types = KrokiDiagramTypes(self.config['EnableBlockDiag'],
                                                self.config['Enablebpmn'],
                                                self.config['EnableExcalidraw'],
-                                               self.config['EnableMermaid'])
+                                               self.config['EnableMermaid'],
+                                               self.config['EnableDiagramsnet'])
 
         self.fence_prefix = self.config['FencePrefix']
 


### PR DESCRIPTION
Closes #18.

Not enabled by default as it is still marked as experimental.