### PR TITLE
feature: config User-Agent for client

### DIFF
--- a/kroki/client.py
+++ b/kroki/client.py
@@ -14,9 +14,10 @@ error = partial(log.error, f'{__name__} %s')
 
 
 class KrokiClient():
-    def __init__(self, server_url, http_method, diagram_types: KrokiDiagramTypes):
+    def __init__(self, server_url, http_method, user_agent: str, diagram_types: KrokiDiagramTypes):
         self.server_url = server_url
         self.http_method = http_method
+        self.headers = {"User-Agent": user_agent}
         self.diagram_types = diagram_types
 
         if http_method not in ['GET', 'POST']:
@@ -59,16 +60,19 @@ class KrokiClient():
                 url = self._get_url(kroki_type, kroki_diagram_data, kroki_diagram_options)
 
                 debug(f'get_image_data [GET {url[:50]}..]')
-                r = requests.get(url)
+                r = requests.get(url, headers=self.headers)
             else:  # POST
                 url = self._kroki_uri(kroki_type)
 
                 debug(f'get_image_data [POST {url}]')
 
-                r = requests.post(url, json={
-                    "diagram_source": kroki_diagram_data,
-                    "diagram_options": kroki_diagram_options
-                })
+                r = requests.post(
+                    url,
+                    headers=self.headers,
+                    json={
+                        "diagram_source": kroki_diagram_data,
+                        "diagram_options": kroki_diagram_options
+                    })
 
             debug(f'get_image_data [Response: {r}]')
             if r.status_code == requests.codes.ok:

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -29,6 +29,8 @@ class KrokiPlugin(BasePlugin):
         ('EnableMermaid', config.config_options.Type(bool, default=True)),
         ('EnableDiagramsnet', config.config_options.Type(bool, default=False)),
         ('HttpMethod', config.config_options.Type(str, default='GET')),
+        ('UserAgent', config.config_options.Type(str,
+            default='Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/109.0')),
         ('DownloadImages', config.config_options.Type(bool, default=False)),
         ('EmbedImages', config.config_options.Type(bool, default=False)),
         ('DownloadDir', config.config_options.Type(str, default='images/kroki_generated')),
@@ -61,9 +63,10 @@ class KrokiPlugin(BasePlugin):
                   'Falling back to GET')
             self.config['HttpMethod'] = 'GET'
 
-        self.kroki_client = KrokiClient(self.config['ServerURL'],
-                                        self.config['HttpMethod'],
-                                        self.diagram_types)
+        self.kroki_client = KrokiClient(server_url=self.config['ServerURL'],
+                                        http_method=self.config['HttpMethod'],
+                                        user_agent=self.config['UserAgent'],
+                                        diagram_types=self.diagram_types)
 
         self._tmp_dir = tempfile.TemporaryDirectory(prefix="mkdocs_kroki_")
         self._output_dir = Path(config.get("site_dir", "site"))


### PR DESCRIPTION
Adds `UserAgent` option. Defaults to current Firefox user agent string.

Solves #10