### PR TITLE
Fix/empty site url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ plugins:
 * `HttpMethod` - Http method to use (`GET` or `POST`), default: `GET` (Note: you have to enable `DownloadImages` if you want to use `POST`!)
 * `DownloadImages` - Download diagrams from kroki as static assets instead of just creating kroki links, default: False
 * `DownloadDir` - The asset directory to place downloaded images in, default: images/kroki_generated
+* `UsePathWithoutUrl` - Use paths without explicit URL (starting with `/`); It has only an effect if `DownloadImages` is True, default: False
 * `FileTypes` - File types you want to use, default: [svg], (Note: not all file formats works with all diagram types <https://kroki.io/#support>)
 
 ```yaml

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -72,6 +72,8 @@ class KrokiPlugin(BasePlugin):
         self._output_dir = Path(config.get("site_dir", "site"))
         self._docs_dir = Path(config.get("docs_dir", "docs"))
         self._site_url = config.get("site_url", "/")
+        if self._site_url is None:
+            self._site_url = "/"
 
         self._prepare_download_dir()
 

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -37,6 +37,7 @@ class KrokiPlugin(BasePlugin):
         ('FencePrefix', config.config_options.Type(str, default='kroki-')),
         ('FileTypes', config.config_options.Type(list, default=['svg'])),
         ('FileTypeOverrides', config.config_options.Type(dict, default={})),
+        ('UsePathWithoutUrl', config.config_options.Type(bool, default=False))
     )
 
     fence_prefix = None
@@ -72,7 +73,7 @@ class KrokiPlugin(BasePlugin):
         self._output_dir = Path(config.get("site_dir", "site"))
         self._docs_dir = Path(config.get("docs_dir", "docs"))
         self._site_url = config.get("site_url", "/")
-        if self._site_url is None:
+        if self._site_url is None or self.config['UsePathWithoutUrl']:
             self._site_url = "/"
 
         self._prepare_download_dir()


### PR DESCRIPTION
Introduce `UsePathWithoutUrl` to be able to use paths without an URL.

Fixes #32 