### PR TITLE
Improve handling of the fenced code blocks

### DIFF
--- a/kroki/config.py
+++ b/kroki/config.py
@@ -92,9 +92,5 @@ class KrokiDiagramTypes:
             f"File and Diagram types configured: {self.diagram_types_supporting_file}"
         )
 
-    def get_block_regex(self, fence_prefix: str) -> str:
-        diagram_types_re = "|".join(self.diagram_types_supporting_file.keys())
-        return rf"(?P<fence>^([ ]*)(?:````*|~~~~*))[ ]*{fence_prefix}({diagram_types_re})((?:[ ]?[a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_]+)*)\n(.*?)(?<=\n)(?P=fence)[ ]*$"  # noqa
-
     def get_file_ext(self, kroki_type: str) -> str:
         return self.diagram_types_supporting_file[kroki_type]

--- a/kroki/config.py
+++ b/kroki/config.py
@@ -94,7 +94,7 @@ class KrokiDiagramTypes:
 
     def get_block_regex(self, fence_prefix: str) -> str:
         diagram_types_re = "|".join(self.diagram_types_supporting_file.keys())
-        return rf"(?:```{fence_prefix})({diagram_types_re})((?:\s?[a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_]+)*)\n(.*?)(?:```)"  # noqa
+        return rf"(?P<fence>^([ ]*)(?:````*|~~~~*))[ ]*{fence_prefix}({diagram_types_re})((?:[ ]?[a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_]+)*)\n(.*?)(?<=\n)(?P=fence)[ ]*$"  # noqa
 
     def get_file_ext(self, kroki_type: str) -> str:
         return self.diagram_types_supporting_file[kroki_type]

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -85,9 +85,10 @@ class KrokiPlugin(MkDocsBasePlugin[KrokiPluginConfig]):
     def _replace_kroki_block(
         self, match_obj: re.Match, files: MkDocsFiles, page: MkDocsPage
     ) -> str:
-        kroki_type = match_obj.group(1).lower()
-        kroki_options = match_obj.group(2)
-        kroki_data = match_obj.group(3)
+        kroki_indent = match_obj.group(2)
+        kroki_type = match_obj.group(3).lower()
+        kroki_options = match_obj.group(4)
+        kroki_data = match_obj.group(5)
 
         if kroki_data.startswith(self.from_file_prefix):
             file_name = kroki_data.removeprefix(self.from_file_prefix).strip()
@@ -112,7 +113,7 @@ class KrokiPlugin(MkDocsBasePlugin[KrokiPluginConfig]):
         )
         log.debug(f"{response}")
         if response.is_ok():
-            return f"![Kroki]({response.image_url})"
+            return kroki_indent + f"![Kroki]({response.image_url})"
 
         return f'!!! error "{response.err_msg}"\n\n```\n{kroki_data}\n```'
 
@@ -122,7 +123,7 @@ class KrokiPlugin(MkDocsBasePlugin[KrokiPluginConfig]):
         log.debug(f"on_page_markdown [page: {page}]")
 
         kroki_regex = self.diagram_types.get_block_regex(self.config.FencePrefix)
-        pattern = re.compile(kroki_regex, flags=re.IGNORECASE + re.DOTALL)
+        pattern = re.compile(kroki_regex, flags=re.IGNORECASE + re.DOTALL + re.MULTILINE)
 
         def replace_kroki_block(match_obj):
             return self._replace_kroki_block(match_obj, files, page)


### PR DESCRIPTION
Supports whitespace after the fence. ex:

~~~ markdown
``` plantuml
stuff
```
~~~

Support more than 3 ticks or tildes for code blocks, this is still only a part of the variations in the wilds [1]

Finds the correct matching ending fence by using identation, this required adding some more groups to the regexp and the option MULTILINE. ex.

~~~ markdown
    ```` plantuml
        stuff containing ```
    ````
~~~

[1] - https://pandoc.org/MANUAL.html#fenced-code-blocks

Closes: #34