### PR TITLE
refactor: cleanup unused EmbedImages config option

### DIFF
--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -32,7 +32,6 @@ class KrokiPlugin(BasePlugin):
         ('UserAgent', config.config_options.Type(str,
             default='Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/109.0')),
         ('DownloadImages', config.config_options.Type(bool, default=False)),
-        ('EmbedImages', config.config_options.Type(bool, default=False)),
         ('DownloadDir', config.config_options.Type(str, default='images/kroki_generated')),
         ('FencePrefix', config.config_options.Type(str, default='kroki-')),
         ('FileTypes', config.config_options.Type(list, default=['svg'])),


### PR DESCRIPTION
Relating to #31 this PR removes the unused config value.

A possible solution can be found here: https://github.com/oniboni/mkdocs-inline-svg-plugin