### PR TITLE
Add DBML support

### DIFF
--- a/kroki/config.py
+++ b/kroki/config.py
@@ -21,6 +21,7 @@ class KrokiDiagramTypes():
         "pikchr": ["svg"],
         "umlet": ["png", "svg"],
         "d2": ["svg"],
+        "dbml": ["svg"],
     }
 
     kroki_blockdiag = {


### PR DESCRIPTION
Simple change to add DBML support to the plugin. We have been testing it internally and the DBML diagrams render fine with this added configuration.