### PR TITLE
Adds support for three missing diagram types

### DIFF
--- a/kroki/config.py
+++ b/kroki/config.py
@@ -22,6 +22,9 @@ class KrokiDiagramTypes:
         "umlet": ["png", "svg"],
         "d2": ["svg"],
         "dbml": ["svg"],
+        "tikz": ["png", "svg", "jpeg", "pdf"],
+        "symbolator": ["svg"],
+        "wireviz": ["png", "svg"],
     }
 
     kroki_blockdiag = {

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(PROJ_DIR / "README.md", encoding="utf-8") as f:
 
 setup(
     name="mkdocs-kroki-plugin",
-    version="0.6.1",
+    version="0.6.2",
     description="MkDocs plugin for Kroki-Diagrams",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Added the config lines to enable the three missing diagram types from Kroki (Tikz, Symbolator and WireViz). The output types were taken from the Kroki Diagram Types [page](https://kroki.io/#support).

All three were tested using the examples from Kroki's demos on the front page.