### PR TITLE
Refactoring/image handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,17 +18,17 @@ plugins:
 
 ## Config
 
-* `ServerURL` - URL of your kroki-Server, default: <https://kroki.io>
-* `FencePrefix` - Diagram prefix, default: `kroki-`
-* `EnableBlockDiag` - Enable BlockDiag (and the related Diagrams), default: True
-* `Enablebpmn` - Enable BPMN, default: True
-* `EnableExcalidraw` - Enable Excalidraw, default: True
-* `EnableMermaid` - Enable Mermaid, default: True
-* `EnableDiagramsnet` - Enable diagrams.net (draw.io), default: False
-* `HttpMethod` - Http method to use (`GET` or `POST`), default: `GET` (Note: you have to enable `DownloadImages` if you want to use `POST`!)
-* `DownloadImages` - Download diagrams from kroki as static assets instead of just creating kroki links, default: False
-* `DownloadDir` - The asset directory to place downloaded images in, default: images/kroki_generated
-* `FileTypes` - File types you want to use, default: [svg], (Note: not all file formats works with all diagram types <https://kroki.io/#support>)
+| Key | Descriptiion |
+|---|---|
+| `ServerURL` | URL of your kroki-Server, default: `https://kroki.io` |
+| `FencePrefix` | Diagram prefix, default: `kroki-` |
+| `EnableBlockDiag` | Enable BlockDiag (and the related Diagrams), default: `True` |
+| `Enablebpmn` | Enable BPMN, default: `True` |
+| `EnableExcalidraw` | Enable Excalidraw, default: `True` |
+| `EnableMermaid` | Enable Mermaid, default: `True` |
+| `EnableDiagramsnet` | Enable diagrams.net (draw.io), default: `False` |
+| `HttpMethod` | Http method to use (`GET` or `POST`), default: `GET` <br>(Note: On `POST` the retrieved images are stored next to the including page in the build directory) |
+| `FileTypes` | File types you want to use, default: `[svg]`, (Note: not all file formats work with all diagram types <https://kroki.io/#support>) |
 
 ```yaml
   - kroki:

--- a/kroki/client.py
+++ b/kroki/client.py
@@ -66,7 +66,9 @@ class KrokiClient:
 
         kroki_url = self._kroki_url_base(kroki_type)
         log.debug(f"{kroki_url}/{kroki_data_param}?{kroki_query_param}")
-        KrokiResponse(image_url=f"{kroki_url}/{kroki_data_param}?{kroki_query_param}")
+        return KrokiResponse(
+            image_url=f"{kroki_url}/{kroki_data_param}?{kroki_query_param}"
+        )
 
     def _kroki_post(
         self,

--- a/kroki/config.py
+++ b/kroki/config.py
@@ -1,7 +1,7 @@
 from functools import partial
-from mkdocs.plugins import log
+from mkdocs.plugins import get_plugin_logger
 
-info = partial(log.info, f"{__name__} %s")
+log = get_plugin_logger(__name__)
 
 
 class KrokiDiagramTypes:
@@ -51,13 +51,13 @@ class KrokiDiagramTypes:
 
     def __init__(
         self,
-        blockdiag_enabled,
-        bpmn_enabled,
-        excalidraw_enabled,
-        mermaid_enabled,
-        diagramsnet_enabled,
-        file_types,
-        file_type_overrides,
+        blockdiag_enabled: bool,
+        bpmn_enabled: bool,
+        excalidraw_enabled: bool,
+        mermaid_enabled: bool,
+        diagramsnet_enabled: bool,
+        file_types: list[str],
+        file_type_overrides: dict[str, str],
     ):
         diagram_types = self.kroki_base.copy()
 
@@ -86,11 +86,13 @@ class KrokiDiagramTypes:
         for diagram_type, diagram_file_type in file_type_overrides.items():
             self.diagram_types_supporting_file[diagram_type] = diagram_file_type
 
-        info(f"File and Diagram types configured: {self.diagram_types_supporting_file}")
+        log.info(
+            f"File and Diagram types configured: {self.diagram_types_supporting_file}"
+        )
 
-    def get_block_regex(self, fence_prefix):
+    def get_block_regex(self, fence_prefix: str) -> str:
         diagram_types_re = "|".join(self.diagram_types_supporting_file.keys())
         return rf"(?:```{fence_prefix})({diagram_types_re})((?:\s?[a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_]+)*)\n(.*?)(?:```)"  # noqa
 
-    def get_file_ext(self, kroki_type):
+    def get_file_ext(self, kroki_type: str) -> str:
         return self.diagram_types_supporting_file[kroki_type]

--- a/kroki/config.py
+++ b/kroki/config.py
@@ -86,7 +86,7 @@ class KrokiDiagramTypes:
         for diagram_type, diagram_file_type in file_type_overrides.items():
             self.diagram_types_supporting_file[diagram_type] = diagram_file_type
 
-        log.info(
+        log.debug(
             f"File and Diagram types configured: {self.diagram_types_supporting_file}"
         )
 

--- a/kroki/config.py
+++ b/kroki/config.py
@@ -1,4 +1,3 @@
-from functools import partial
 from mkdocs.plugins import get_plugin_logger
 
 log = get_plugin_logger(__name__)

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -1,139 +1,91 @@
-import hashlib
 import re
-import tempfile
-
-from functools import partial
-from mkdocs.plugins import BasePlugin
-from mkdocs.structure.files import File
-from mkdocs import config
-from mkdocs.plugins import log
-from pathlib import Path
-from os.path import relpath
 import os
 
-from .config import KrokiDiagramTypes
-from .client import KrokiClient
+from mkdocs.config.base import Config as MkDocsBaseConfig
+from mkdocs.config.config_options import (
+    Type as MkDocsConfigType,
+    URL as MKDocsConfigURL,
+    Choice as MKDocsConfigChoice,
+    Deprecated as MKDocsConfigDeprecated,
+)
+from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.plugins import BasePlugin as MkDocsBasePlugin, get_plugin_logger
+from mkdocs.structure.files import Files as MkDocsFiles
+from mkdocs.structure.pages import Page as MkDocsPage
+from pathlib import Path
+
+from kroki.config import KrokiDiagramTypes
+from kroki.client import KrokiClient, KrokiResponse
+
+log = get_plugin_logger(__name__)
 
 
-info = partial(log.info, f"{__name__} %s")
-debug = partial(log.debug, f"{__name__} %s")
-error = partial(log.error, f"{__name__} %s")
-
-
-class KrokiPlugin(BasePlugin):
-    config_scheme = (
-        (
-            "ServerURL",
-            config.config_options.Type(
-                str, default=os.getenv("KROKI_SERVER_URL", "https://kroki.io")
-            ),
-        ),
-        ("EnableBlockDiag", config.config_options.Type(bool, default=True)),
-        ("Enablebpmn", config.config_options.Type(bool, default=True)),
-        ("EnableExcalidraw", config.config_options.Type(bool, default=True)),
-        ("EnableMermaid", config.config_options.Type(bool, default=True)),
-        ("EnableDiagramsnet", config.config_options.Type(bool, default=False)),
-        ("HttpMethod", config.config_options.Type(str, default="GET")),
-        (
-            "UserAgent",
-            config.config_options.Type(
-                str,
-                default="Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/109.0",  # noqa
-            ),
-        ),
-        ("DownloadImages", config.config_options.Type(bool, default=False)),
-        (
-            "DownloadDir",
-            config.config_options.Type(str, default="images/kroki_generated"),
-        ),
-        ("FencePrefix", config.config_options.Type(str, default="kroki-")),
-        ("FileTypes", config.config_options.Type(list, default=["svg"])),
-        ("FileTypeOverrides", config.config_options.Type(dict, default={})),
+class KrokiPluginConfig(MkDocsBaseConfig):
+    ServerURL = MKDocsConfigURL(
+        default=os.getenv("KROKI_SERVER_URL", "https://kroki.io")
     )
+    EnableBlockDiag = MkDocsConfigType(bool, default=True)
+    Enablebpmn = MkDocsConfigType(bool, default=True)
+    EnableExcalidraw = MkDocsConfigType(bool, default=True)
+    EnableMermaid = MkDocsConfigType(bool, default=True)
+    EnableDiagramsnet = MkDocsConfigType(bool, default=False)
+    HttpMethod = MKDocsConfigChoice(choices=["GET", "POST"], default="GET")
+    UserAgent = MkDocsConfigType(str, default=f"{__name__}/0.6.1")
+    FencePrefix = MkDocsConfigType(str, default="kroki-")
+    FileTypes = MkDocsConfigType(list, default=["svg"])
+    FileTypeOverrides = MkDocsConfigType(dict, default={})
 
-    fence_prefix = None
-    diagram_types = None
-    kroki_client = None
+    DownloadImages = MKDocsConfigDeprecated(moved_to="HttpMethod: 'POST'")
+    DownloadDir = MKDocsConfigDeprecated(removed=True)
+
+
+class KrokiPlugin(MkDocsBasePlugin[KrokiPluginConfig]):
+    diagram_types: KrokiDiagramTypes
+    kroki_client: KrokiClient
     from_file_prefix = "@from_file:"
-    from_file_prefix_len = len(from_file_prefix)
+    global_config: MkDocsConfig
 
-    def on_config(self, config, **_kwargs):
-        info(f"Configuring: {self.config}")
+    def on_config(self, config: MkDocsConfig) -> MkDocsConfig:
+        log.debug(f"Configuring: {self.config}")
 
         self.diagram_types = KrokiDiagramTypes(
-            self.config["EnableBlockDiag"],
-            self.config["Enablebpmn"],
-            self.config["EnableExcalidraw"],
-            self.config["EnableMermaid"],
-            self.config["EnableDiagramsnet"],
-            self.config["FileTypes"],
-            self.config["FileTypeOverrides"],
+            self.config.EnableBlockDiag,
+            self.config.Enablebpmn,
+            self.config.EnableExcalidraw,
+            self.config.EnableMermaid,
+            self.config.EnableDiagramsnet,
+            self.config.FileTypes,
+            self.config.FileTypeOverrides,
         )
 
-        self.fence_prefix = self.config["FencePrefix"]
-
-        if self.config["HttpMethod"] == "POST" and not self.config["DownloadImages"]:
-            error(
-                "HttpMethod: Can't use POST without downloading the images! "
-                "Falling back to GET"
-            )
-            self.config["HttpMethod"] = "GET"
-
         self.kroki_client = KrokiClient(
-            server_url=self.config["ServerURL"],
-            http_method=self.config["HttpMethod"],
-            user_agent=self.config["UserAgent"],
+            server_url=self.config.ServerURL,
+            http_method=self.config.HttpMethod,
+            user_agent=self.config.UserAgent,
             diagram_types=self.diagram_types,
         )
 
-        self._tmp_dir = tempfile.TemporaryDirectory(prefix="mkdocs_kroki_")
-        self._output_dir = Path(config.get("site_dir", "site"))
-        self._docs_dir = Path(config.get("docs_dir", "docs"))
-        self._site_url = config.get("site_url", "/")
-
-        self._prepare_download_dir()
+        self.global_config = config
 
         return config
 
-    def _download_dir(self):
-        return Path(self._tmp_dir.name) / Path(self.config["DownloadDir"])
-
-    def _prepare_download_dir(self):
-        self._download_dir().mkdir(parents=True, exist_ok=True)
-
-    def _kroki_filename(self, kroki_data, kroki_type, page):
-        digest = hashlib.md5(kroki_data.encode("utf8")).hexdigest()
-        prefix = page.file.name.split(".")[0]
-        file_type = self.diagram_types.get_file_ext(kroki_type)
-
-        return f"{prefix}-{digest}.{file_type}"
-
-    def _save_kroki_image_and_get_url(self, file_name, image_data, files):
-        filepath = self._download_dir() / file_name
-        with open(filepath, "wb") as file:
-            file.write(image_data)
-        get_url = relpath(filepath, self._tmp_dir.name)
-
-        mkdocs_file = File(get_url, self._tmp_dir.name, self._output_dir, False)
-        files.append(mkdocs_file)
-
-        return f"{self._site_url}{mkdocs_file.url}"
-
-    def _replace_kroki_block(self, match_obj, files, page):
+    def _replace_kroki_block(
+        self, match_obj: re.Match, files: MkDocsFiles, page: MkDocsPage
+    ) -> str:
         kroki_type = match_obj.group(1).lower()
         kroki_options = match_obj.group(2)
         kroki_data = match_obj.group(3)
 
         if kroki_data.startswith(self.from_file_prefix):
-            file_name = kroki_data[self.from_file_prefix_len :].strip()  # noqa
-            file_path = self._docs_dir / file_name
-            info(f'reading kroki block from file: "{file_path.absolute()}"')
+            file_name = kroki_data.removeprefix(self.from_file_prefix).strip()
+            file_path = Path(self.global_config.docs_dir) / file_name
+            log.debug(f'Reading kroki block from file: "{file_path.absolute()}"')
             try:
                 with open(file_path) as data_file:
                     kroki_data = data_file.read()
             except OSError:
                 msg = f'Can\'t read file: "{file_path.absolute()}"'
-                error(msg)
+                log.error(msg)
                 return f"!!! error {msg}"
 
         kroki_diagram_options = (
@@ -141,39 +93,25 @@ class KrokiPlugin(BasePlugin):
             if kroki_options
             else {}
         )
-        get_url = None
-        if self.config["DownloadImages"]:
-            image_data = self.kroki_client.get_image_data(
-                kroki_type, kroki_data, kroki_diagram_options
-            )
 
-            if image_data:
-                file_name = self._kroki_filename(kroki_data, kroki_type, page)
-                get_url = self._save_kroki_image_and_get_url(
-                    file_name, image_data, files
-                )
-        else:
-            get_url = self.kroki_client.get_url(
-                kroki_type, kroki_data, kroki_diagram_options
-            )
+        response: KrokiResponse = self.kroki_client.get_image_url(
+            kroki_type, kroki_data, kroki_diagram_options, files, page
+        )
+        log.debug(f"{response}")
+        if response.is_ok():
+            return f"![Kroki]({response.image_url})"
 
-        if get_url is not None:
-            return f"![Kroki]({get_url})"
+        return f'!!! error "{response.err_msg}"\n\n```\n{kroki_data}\n```'
 
-        return f'!!! error "Could not render!"\n\n```\n{kroki_data}\n```'
+    def on_page_markdown(
+        self, markdown: str, files: MkDocsFiles, page: MkDocsPage, **_kwargs
+    ) -> str:
+        log.debug(f"on_page_markdown [page: {page}]")
 
-    def on_page_markdown(self, markdown, files, page, **_kwargs):
-        debug(f"on_page_markdown [page: {page}]")
-
-        kroki_regex = self.diagram_types.get_block_regex(self.fence_prefix)
+        kroki_regex = self.diagram_types.get_block_regex(self.config.FencePrefix)
         pattern = re.compile(kroki_regex, flags=re.IGNORECASE + re.DOTALL)
 
         def replace_kroki_block(match_obj):
             return self._replace_kroki_block(match_obj, files, page)
 
         return re.sub(pattern, replace_kroki_block, markdown)
-
-    def on_post_build(self, **_kwargs):
-        if hasattr(self, "_tmp_dir"):
-            info(f"Cleaning {self._tmp_dir}")
-            self._tmp_dir.cleanup()

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -4,9 +4,9 @@ import os
 from mkdocs.config.base import Config as MkDocsBaseConfig
 from mkdocs.config.config_options import (
     Type as MkDocsConfigType,
-    URL as MKDocsConfigURL,
-    Choice as MKDocsConfigChoice,
-    Deprecated as MKDocsConfigDeprecated,
+    URL as MkDocsConfigURL,
+    Choice as MkDocsConfigChoice,
+    Deprecated as MkDocsConfigDeprecated,
 )
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import BasePlugin as MkDocsBasePlugin, get_plugin_logger
@@ -20,7 +20,7 @@ from kroki.client import KrokiClient, KrokiResponse
 log = get_plugin_logger(__name__)
 
 
-class DeprecatedDownloadImagesCompat(MKDocsConfigDeprecated):
+class DeprecatedDownloadImagesCompat(MkDocsConfigDeprecated):
     def pre_validation(self, config: "KrokiPluginConfig", key_name: str) -> None:
         """Set `HttpMethod: 'POST'`, if enabled"""
         if config.get(key_name) is None:
@@ -34,7 +34,7 @@ class DeprecatedDownloadImagesCompat(MKDocsConfigDeprecated):
 
 
 class KrokiPluginConfig(MkDocsBaseConfig):
-    ServerURL = MKDocsConfigURL(
+    ServerURL = MkDocsConfigURL(
         default=os.getenv("KROKI_SERVER_URL", "https://kroki.io")
     )
     EnableBlockDiag = MkDocsConfigType(bool, default=True)
@@ -42,14 +42,14 @@ class KrokiPluginConfig(MkDocsBaseConfig):
     EnableExcalidraw = MkDocsConfigType(bool, default=True)
     EnableMermaid = MkDocsConfigType(bool, default=True)
     EnableDiagramsnet = MkDocsConfigType(bool, default=False)
-    HttpMethod = MKDocsConfigChoice(choices=["GET", "POST"], default="GET")
+    HttpMethod = MkDocsConfigChoice(choices=["GET", "POST"], default="GET")
     UserAgent = MkDocsConfigType(str, default=f"{__name__}/0.6.1")
     FencePrefix = MkDocsConfigType(str, default="kroki-")
     FileTypes = MkDocsConfigType(list, default=["svg"])
     FileTypeOverrides = MkDocsConfigType(dict, default={})
 
     DownloadImages = DeprecatedDownloadImagesCompat(moved_to="HttpMethod: 'POST'")
-    DownloadDir = MKDocsConfigDeprecated(removed=True)
+    DownloadDir = MkDocsConfigDeprecated(removed=True)
 
 
 class KrokiPlugin(MkDocsBasePlugin[KrokiPluginConfig]):

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -20,6 +20,19 @@ from kroki.client import KrokiClient, KrokiResponse
 log = get_plugin_logger(__name__)
 
 
+class DeprecatedDownloadImagesCompat(MKDocsConfigDeprecated):
+    def pre_validation(self, config: "KrokiPluginConfig", key_name: str) -> None:
+        """Set `HttpMethod: 'POST'`, if enabled"""
+        if config.get(key_name) is None:
+            return
+
+        self.warnings.append(self.message.format(key_name))
+
+        DownloadImages: bool = config.pop(key_name)
+        if DownloadImages:
+            config.HttpMethod = "POST"
+
+
 class KrokiPluginConfig(MkDocsBaseConfig):
     ServerURL = MKDocsConfigURL(
         default=os.getenv("KROKI_SERVER_URL", "https://kroki.io")
@@ -35,7 +48,7 @@ class KrokiPluginConfig(MkDocsBaseConfig):
     FileTypes = MkDocsConfigType(list, default=["svg"])
     FileTypeOverrides = MkDocsConfigType(dict, default={})
 
-    DownloadImages = MKDocsConfigDeprecated(moved_to="HttpMethod: 'POST'")
+    DownloadImages = DeprecatedDownloadImagesCompat(moved_to="HttpMethod: 'POST'")
     DownloadDir = MKDocsConfigDeprecated(removed=True)
 
 

--- a/kroki/util.py
+++ b/kroki/util.py
@@ -1,0 +1,46 @@
+from uuid import uuid3, NAMESPACE_OID
+from mkdocs.structure.files import Files as MkDocsFiles, File as MkDocsFile
+from mkdocs.structure.pages import Page as MkDocsPage
+from mkdocs.plugins import get_plugin_logger
+
+
+from os import path, makedirs
+
+log = get_plugin_logger(__name__)
+
+
+class DownloadedImage:
+    def __init__(
+        self, file_content: bytes, file_extension: str, additional_metadata: dict
+    ) -> None:
+        file_uuid = uuid3(NAMESPACE_OID, f"{additional_metadata}{file_content}")
+
+        self.file_name = f"kroki-generated-{file_uuid}.{file_extension}"
+        self.file_content = file_content
+
+    def save(self, files: MkDocsFiles, page: MkDocsPage) -> None:
+        # wherever MkDocs wants to host or build, we plant the image next
+        # to the generated static page
+        page_abs_dest_dir = path.dirname(page.file.abs_dest_path)
+        makedirs(page_abs_dest_dir, exist_ok=True)
+
+        file_path = path.join(page_abs_dest_dir, self.file_name)
+
+        with open(file_path, "wb") as file:
+            file.write(self.file_content)
+
+        # make MkDocs believe that the file was present from the beginning
+        file_src_uri = path.join(path.dirname(page.file.src_uri), self.file_name)
+        file_dest_uri = path.join(path.dirname(page.file.dest_uri), self.file_name)
+
+        dummy_file = MkDocsFile(
+            path=file_src_uri,
+            src_dir="",
+            dest_dir="",
+            use_directory_urls=False,
+            dest_uri=file_dest_uri,
+        )
+        # MkDocs will not copy the file in this case
+        dummy_file.abs_src_path = dummy_file.abs_dest_path = file_path
+
+        files.append(dummy_file)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email="benjamin.bittner@avateam.com",
     license="MIT",
     python_requires=">=3.6",
-    install_requires=["mkdocs>=1.3.0", "requests>=2.27.0"],
+    install_requires=["mkdocs>=1.4.0", "requests>=2.27.0"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
fix: downloaded image handling

* place referenced image files next to page
* take metadata into account for image name generation
* update to mkdocs 1.4 plugin config
* remove temp dir and download dir
* deprecate `DownloadImages` -> `HttpMethod='POST'` realizes this
  functionality as well
   * let option automatically set HttpMethod: 'POST' for compatibility
* deprecate `DownloadDir` option to get rid of relative and absolute
  path issues
* move kroki response handling to kroki client
* add type hints
* docs: update config section

Fixes #11, fixes #32, fixes #39, fixes #41

