### PR TITLE
Close img tag to comply standards

### DIFF
--- a/kroki/render.py
+++ b/kroki/render.py
@@ -62,7 +62,7 @@ class ContentRenderer:
             case "svg":
                 return ContentRenderer._svg_data(image_src)
             case "img":
-                return f'<img alt="Kroki" src="{image_src.url}">'
+                return f'<img alt="Kroki" src="{image_src.url}" />'
             case _:
                 err_msg = "Unknown tag format set."
                 raise PluginError(err_msg)


### PR DESCRIPTION
I ran into a problem with a markdown parser, because it tried to analyze html as well and pops errors, because of missing slash.