### PR TITLE
Also capture {} as option while parsing markdown

### DIFF
--- a/kroki/parsing.py
+++ b/kroki/parsing.py
@@ -16,7 +16,7 @@ class MarkdownParser:
     _FENCE_RE = re.compile(
         r"(?P<fence>^(?P<indent>[ ]*)(?:````*|~~~~*))[ ]*"
         r"(\.?(?P<lang>[\w#.+-]*)[ ]*)?"
-        r"(?P<opts>(?:[ ]?[a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_]+)*)\n"
+        r"(?P<opts>(?:[ ]?[\{a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_\}]+)*)\n"
         r"(?P<code>.*?)(?<=\n)"
         r"(?P=fence)[ ]*$",
         flags=re.IGNORECASE + re.DOTALL + re.MULTILINE,


### PR DESCRIPTION
Some VS code plugins want you to add {kroki=true} as an option to the language identifier, but if that is added, mkdocs-kroki-plugin does not recognize it anymore.