### PR TITLE
feat: Add theme-aware styles with styles_light and styles_dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ plugins:
 | `diagram_background_color_light` | Background color for diagrams in light mode (CSS color value)                                                                                 | (none)                                        |
 | `diagram_background_color_dark`  | Background color for diagrams in dark mode (CSS color value)                                                                                  | (none)                                        |
 | `styles`                         | Global style map for diagram elements (`box`, `actor`, `note`, `package`, `text`, `line`, `background`). See [Global Styles](#global-styles).                    | (none)                                        |
+| `styles_light`                   | Style map applied in light mode. Use together with `styles_dark` for theme-aware diagrams. See [Theme-Aware Styles](#theme-aware-styles).      | (none)                                        |
+| `styles_dark`                    | Style map applied in dark mode. Use together with `styles_light` for theme-aware diagrams. See [Theme-Aware Styles](#theme-aware-styles).      | (none)                                        |
 
 Example:
 
@@ -286,6 +288,49 @@ graph LR
 \*BlockDiag includes: blockdiag, seqdiag, actdiag, nwdiag, packetdiag, rackdiag.
 
 Diagram types not listed (BPMN, ByteField, DBML, Ditaa, ERD, Excalidraw, Pikchr, SVGBob, Symbolator, TikZ, UMlet, Vega, VegaLite, WaveDrom, WireViz, diagrams.net) do not support source-level style injection.
+
+### Theme-Aware Styles
+
+When you need different diagram colors for light and dark mode — not just a different background, but different fills, strokes, and text colors baked into the diagram itself — use `styles_light` and `styles_dark` together.
+
+```yaml
+plugins:
+  - kroki:
+      styles_light:
+        box:
+          fill: "#e8f4fd"
+          stroke: "#0066cc"
+        text:
+          fill: "#24292e"
+        background:
+          fill: "#ffffff"
+      styles_dark:
+        box:
+          fill: "#1a2a3a"
+          stroke: "#4da6ff"
+        text:
+          fill: "#e0e0e0"
+        background:
+          fill: "#1e1e1e"
+```
+
+The plugin renders **two versions** of each diagram — one with light styles, one with dark — and emits two `<img>` tags using [MkDocs Material's light/dark image feature](https://squidfunk.github.io/mkdocs-material/reference/images/#light-and-dark-mode):
+
+```html
+<img alt="Kroki" src="diagram-light.svg#only-light" />
+<img alt="Kroki" src="diagram-dark.svg#only-dark" />
+```
+
+Material's CSS then shows the correct image based on the active color scheme.
+
+**Notes:**
+
+- Requires **MkDocs Material** theme — the `#only-light`/`#only-dark` mechanism is Material-specific
+- Requires `tag_format: img` (the default). `object` and `svg` formats fall back to light-mode styles only with a warning
+- Requires `http_method: POST` (images must be downloaded to use this feature)
+- `styles_light`/`styles_dark` take precedence over `styles` when set; using all three simultaneously logs a warning
+- The `no-style-inject=true` per-diagram option skips injection for both light and dark
+- Supports the same style properties and diagram types as the single `styles` config (see [Support Matrix](#support-matrix))
 
 ## Contributors
 

--- a/kroki/common.py
+++ b/kroki/common.py
@@ -56,3 +56,4 @@ class KrokiImageContext:
     options: dict
     plugin_options: dict
     data: Result[str, ErrorResult]
+    data_dark: Result[str, ErrorResult] | None = None

--- a/kroki/config.py
+++ b/kroki/config.py
@@ -33,6 +33,8 @@ class KrokiPluginConfig(MkDocsBaseConfig):
     diagram_background_color_light = config_options.Optional(config_options.Type(str))
     diagram_background_color_dark = config_options.Optional(config_options.Type(str))
     styles = config_options.Optional(config_options.Type(dict))
+    styles_light = config_options.Optional(config_options.Type(dict))
+    styles_dark = config_options.Optional(config_options.Type(dict))
 
     def validate(self) -> tuple[MkDocsConfigErrors, MkDocsConfigWarnings]:
         result = super().validate()
@@ -40,5 +42,11 @@ class KrokiPluginConfig(MkDocsBaseConfig):
         if self["tag_format"] == "svg" and self["http_method"] != "POST":
             log.info("Setting Http method to POST to retrieve svg data for inlining.")
             self["http_method"] = "POST"
+
+        if self["styles"] and (self["styles_light"] or self["styles_dark"]):
+            log.warning(
+                "Both 'styles' and 'styles_light'/'styles_dark' are set. "
+                "'styles' will be ignored in favour of 'styles_light'/'styles_dark'."
+            )
 
         return result

--- a/kroki/parsing.py
+++ b/kroki/parsing.py
@@ -35,10 +35,14 @@ class MarkdownParser:
         diagram_types: KrokiDiagramTypes,
         *,
         style_injector: StyleInjector | None = None,
+        style_injector_light: StyleInjector | None = None,
+        style_injector_dark: StyleInjector | None = None,
     ) -> None:
         self.diagram_types = diagram_types
         self.docs_dir = docs_dir
         self.style_injector = style_injector
+        self.style_injector_light = style_injector_light
+        self.style_injector_dark = style_injector_dark
 
     def _get_block_content(self, block_data: str) -> Result[str, ErrorResult]:
         if not block_data.startswith(_FROM_FILE_PREFIX):
@@ -96,18 +100,38 @@ class MarkdownParser:
                             options[key] = value
 
             data = self._get_block_content(textwrap.dedent(match_obj.group("code")))
-            if (
-                self.style_injector is not None
-                and "no-style-inject" not in plugin_options
-                and data.is_ok()
-            ):
-                data = Ok(self.style_injector.inject(kroki_type, data.unwrap()))
+            data_dark: Result[str, ErrorResult] | None = None
+            skip_inject = "no-style-inject" in plugin_options
+
+            if not skip_inject and data.is_ok():
+                original_source = data.unwrap()
+                if (
+                    self.style_injector_light is not None
+                    and self.style_injector_dark is not None
+                ):
+                    data = Ok(
+                        self.style_injector_light.inject(kroki_type, original_source)
+                    )
+                    data_dark = Ok(
+                        self.style_injector_dark.inject(kroki_type, original_source)
+                    )
+                elif self.style_injector is not None:
+                    data = Ok(self.style_injector.inject(kroki_type, original_source))
+                elif self.style_injector_light is not None:
+                    data = Ok(
+                        self.style_injector_light.inject(kroki_type, original_source)
+                    )
+                elif self.style_injector_dark is not None:
+                    data = Ok(
+                        self.style_injector_dark.inject(kroki_type, original_source)
+                    )
 
             kroki_context = KrokiImageContext(
                 kroki_type=kroki_type,
                 options=options,
                 plugin_options=plugin_options,
                 data=data,
+                data_dark=data_dark,
             )
             match_data.append((match_obj, kroki_context))
             tasks.append(block_callback(kroki_context, context))

--- a/kroki/plugin.py
+++ b/kroki/plugin.py
@@ -51,11 +51,26 @@ class KrokiPlugin(MkDocsBasePlugin[KrokiPluginConfig]):
             diagram_types=self.diagram_types,
             cache=self.cache,
         )
+        style_injector_light = (
+            StyleInjector(self.config.styles_light)
+            if self.config.styles_light
+            else None
+        )
+        style_injector_dark = (
+            StyleInjector(self.config.styles_dark) if self.config.styles_dark else None
+        )
+        # Use single styles only when no themed styles are configured
         style_injector = (
-            StyleInjector(self.config.styles) if self.config.styles else None
+            StyleInjector(self.config.styles)
+            if self.config.styles and not (style_injector_light or style_injector_dark)
+            else None
         )
         self.parser = MarkdownParser(
-            config.docs_dir, self.diagram_types, style_injector=style_injector
+            config.docs_dir,
+            self.diagram_types,
+            style_injector=style_injector,
+            style_injector_light=style_injector_light,
+            style_injector_dark=style_injector_dark,
         )
         self.renderer = ContentRenderer(
             self.kroki_client,

--- a/kroki/render.py
+++ b/kroki/render.py
@@ -1,3 +1,4 @@
+import asyncio
 from xml.etree import ElementTree as XmlElementTree
 
 from defusedxml import ElementTree as DefuseElementTree
@@ -152,9 +153,78 @@ class ContentRenderer:
             "</details>"
         )
 
+    def _dual_image_response(
+        self,
+        image_src_light: ImageSrc,
+        image_src_dark: ImageSrc,
+        plugin_options: dict,
+    ) -> str:
+        style_attr = self._build_style_attr(plugin_options)
+        return (
+            f'<img alt="Kroki" src="{image_src_light.url}#only-light"{style_attr} />'
+            f'<img alt="Kroki" src="{image_src_dark.url}#only-dark"{style_attr} />'
+        )
+
+    async def _render_dual(
+        self, kroki_context: KrokiImageContext, context: MkDocsEventContext
+    ) -> str:
+        if self.tag_format != "img":
+            log.warning(
+                "Dual theme styles (styles_light/styles_dark) require tag_format 'img'. "
+                "Falling back to light-mode styles only."
+            )
+            match kroki_context.data:
+                case Ok(kroki_data):
+                    match await self.kroki_client.get_image_url(kroki_context, context):
+                        case Ok(image_src):
+                            return self._image_response(
+                                image_src, kroki_context.plugin_options
+                            )
+                        case Err(err_result):
+                            return self._err_response(err_result, kroki_data)
+                case Err(err_result):
+                    return self._err_response(err_result)
+
+        # Build a dark-mode context to fetch the dark image
+        dark_context = KrokiImageContext(
+            kroki_type=kroki_context.kroki_type,
+            options=kroki_context.options,
+            plugin_options=kroki_context.plugin_options,
+            data=kroki_context.data_dark,
+        )
+
+        match kroki_context.data:
+            case Err(err_result):
+                return self._err_response(err_result)
+
+        match kroki_context.data_dark:
+            case Err(err_result):
+                return self._err_response(err_result)
+
+        light_result, dark_result = await asyncio.gather(
+            self.kroki_client.get_image_url(kroki_context, context),
+            self.kroki_client.get_image_url(dark_context, context),
+        )
+
+        match light_result:
+            case Err(err_result):
+                return self._err_response(err_result, kroki_context.data.unwrap())
+        match dark_result:
+            case Err(err_result):
+                return self._err_response(err_result, kroki_context.data_dark.unwrap())
+
+        return self._dual_image_response(
+            light_result.unwrap(),
+            dark_result.unwrap(),
+            kroki_context.plugin_options,
+        )
+
     async def render_kroki_block(
         self, kroki_context: KrokiImageContext, context: MkDocsEventContext
     ) -> str:
+        if kroki_context.data_dark is not None:
+            return await self._render_dual(kroki_context, context)
+
         match kroki_context.data:
             case Ok(kroki_data):
                 match await self.kroki_client.get_image_url(kroki_context, context):

--- a/kroki/render.py
+++ b/kroki/render.py
@@ -186,6 +186,7 @@ class ContentRenderer:
                     return self._err_response(err_result)
 
         # Build a dark-mode context to fetch the dark image
+        assert kroki_context.data_dark is not None
         dark_context = KrokiImageContext(
             kroki_type=kroki_context.kroki_type,
             options=kroki_context.options,
@@ -211,7 +212,7 @@ class ContentRenderer:
                 return self._err_response(err_result, kroki_context.data.unwrap())
         match dark_result:
             case Err(err_result):
-                return self._err_response(err_result, kroki_context.data_dark.unwrap())
+                return self._err_response(err_result, dark_context.data.unwrap())
 
         return self._dual_image_response(
             light_result.unwrap(),

--- a/playground/mkdocs.yml
+++ b/playground/mkdocs.yml
@@ -1,15 +1,34 @@
 site_name: Kroki Plugin Playground
 docs_dir: docs
 
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+      primary: blue
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+      primary: blue
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+      primary: blue
 
 plugins:
-  - search
   - kroki:
       fence_prefix: ''
       http_method: POST
-      diagram_background_color_light: "#f8f8f8"
-      diagram_background_color_dark: "#999696"
-      styles:
+#      diagram_background_color_light: "transparent"
+#      diagram_background_color_dark: "transparent"
+      styles_light:
         box:
           fill: "#fce4c6"
           stroke: "#D65108"
@@ -32,8 +51,23 @@ plugins:
           stroke: "#D65108"
           label-background: "#fce4c6"
         background:
-          fill: "#fdf6ef"
-  - techdocs-core
+          fill: transparent
+      styles_dark:
+        box:
+          fill: "#3a2010"
+          stroke: "#ff8c42"
+        actor:
+          fill: "#2e1a0e"
+          stroke: "#cc6a1e"
+        text:
+          fill: "#e8d5c4"
+          font-family: "Arial"
+          font-size: "13"
+        line:
+          stroke: "#ff8c42"
+          label-background: "#3a2010"
+        background:
+          fill: transparent
 
 nav:
   - Home: index.md

--- a/tests/test_theme_styles.py
+++ b/tests/test_theme_styles.py
@@ -1,0 +1,256 @@
+import textwrap
+from unittest.mock import MagicMock
+
+import bs4
+import pytest
+
+from kroki.parsing import MarkdownParser
+from kroki.styles import StyleInjector
+from tests.utils import MkDocsTemplateHelper
+
+_LIGHT_STYLES = {"box": {"fill": "#e8f4fd", "stroke": "#0066cc"}}
+_DARK_STYLES = {"box": {"fill": "#1a2a3a", "stroke": "#4da6ff"}}
+
+
+# --- Unit tests for MarkdownParser dual injection ---
+
+
+def test_dual_style_injectors_populate_data_dark(
+    mock_kroki_diagram_types, kroki_dummy
+) -> None:
+    injector_light = StyleInjector(_LIGHT_STYLES)
+    injector_dark = StyleInjector(_DARK_STYLES)
+    parser = MarkdownParser(
+        "/tmp",
+        mock_kroki_diagram_types,
+        style_injector_light=injector_light,
+        style_injector_dark=injector_dark,
+    )
+    md = textwrap.dedent("""\
+        ```plantuml
+        @startuml
+        Alice -> Bob
+        @enduml
+        ```
+    """)
+    captured = []
+
+    async def capture_callback(kroki_context, mkdocs_context):
+        captured.append(kroki_context)
+        return "<img />"
+
+    parser.replace_kroki_blocks(md, capture_callback, MagicMock())
+    assert len(captured) == 1
+    ctx = captured[0]
+    assert ctx.data_dark is not None
+    assert "skinparam RectangleBackgroundColor #e8f4fd" in ctx.data.unwrap()
+    assert "skinparam RectangleBackgroundColor #1a2a3a" in ctx.data_dark.unwrap()
+
+
+def test_single_style_injector_leaves_data_dark_none(
+    mock_kroki_diagram_types, kroki_dummy
+) -> None:
+    parser = MarkdownParser(
+        "/tmp",
+        mock_kroki_diagram_types,
+        style_injector=StyleInjector(_LIGHT_STYLES),
+    )
+    md = textwrap.dedent("""\
+        ```plantuml
+        @startuml
+        Alice -> Bob
+        @enduml
+        ```
+    """)
+    captured = []
+
+    async def capture_callback(kroki_context, mkdocs_context):
+        captured.append(kroki_context)
+        return "<img />"
+
+    parser.replace_kroki_blocks(md, capture_callback, MagicMock())
+    assert captured[0].data_dark is None
+
+
+def test_no_style_inject_skips_both_injectors(
+    mock_kroki_diagram_types, kroki_dummy
+) -> None:
+    parser = MarkdownParser(
+        "/tmp",
+        mock_kroki_diagram_types,
+        style_injector_light=StyleInjector(_LIGHT_STYLES),
+        style_injector_dark=StyleInjector(_DARK_STYLES),
+    )
+    md = textwrap.dedent("""\
+        ```plantuml no-style-inject=true
+        @startuml
+        Alice -> Bob
+        @enduml
+        ```
+    """)
+    captured = []
+
+    async def capture_callback(kroki_context, mkdocs_context):
+        captured.append(kroki_context)
+        return "<img />"
+
+    parser.replace_kroki_blocks(md, capture_callback, MagicMock())
+    ctx = captured[0]
+    assert ctx.data_dark is None
+    assert "skinparam" not in ctx.data.unwrap()
+
+
+def test_only_light_injector_set_leaves_data_dark_none(
+    mock_kroki_diagram_types, kroki_dummy
+) -> None:
+    parser = MarkdownParser(
+        "/tmp",
+        mock_kroki_diagram_types,
+        style_injector_light=StyleInjector(_LIGHT_STYLES),
+    )
+    md = textwrap.dedent("""\
+        ```plantuml
+        @startuml
+        Alice -> Bob
+        @enduml
+        ```
+    """)
+    captured = []
+
+    async def capture_callback(kroki_context, mkdocs_context):
+        captured.append(kroki_context)
+        return "<img />"
+
+    parser.replace_kroki_blocks(md, capture_callback, MagicMock())
+    ctx = captured[0]
+    assert ctx.data_dark is None
+    assert "skinparam RectangleBackgroundColor #e8f4fd" in ctx.data.unwrap()
+
+
+# --- Integration tests ---
+
+
+@pytest.mark.usefixtures("kroki_dummy")
+def test_dual_styles_renders_two_img_tags() -> None:
+    code_block = """```plantuml
+@startuml
+A -> B
+@enduml
+```"""
+    with MkDocsTemplateHelper(code_block) as mkdocs_helper:
+        mkdocs_helper.set_http_method("POST")
+        mkdocs_helper.set_tag_format("img")
+        mkdocs_helper.set_styles_light(_LIGHT_STYLES)
+        mkdocs_helper.set_styles_dark(_DARK_STYLES)
+        result = mkdocs_helper.invoke_build()
+
+        assert result.exit_code == 0
+        with open(mkdocs_helper.test_dir / "site/index.html") as f:
+            soup = bs4.BeautifulSoup(f.read(), features="html.parser")
+
+    imgs = soup.find_all("img", attrs={"alt": "Kroki"})
+    assert len(imgs) == 2
+
+    srcs = [img["src"] for img in imgs]
+    assert any("#only-light" in src for src in srcs)
+    assert any("#only-dark" in src for src in srcs)
+
+
+@pytest.mark.usefixtures("kroki_dummy")
+def test_dual_styles_each_img_has_correct_hash_fragment() -> None:
+    """Each img must carry exactly one of the two theme hash fragments."""
+    code_block = """```plantuml
+@startuml
+A -> B
+@enduml
+```"""
+    with MkDocsTemplateHelper(code_block) as mkdocs_helper:
+        mkdocs_helper.set_http_method("POST")
+        mkdocs_helper.set_tag_format("img")
+        mkdocs_helper.set_styles_light(_LIGHT_STYLES)
+        mkdocs_helper.set_styles_dark(_DARK_STYLES)
+        result = mkdocs_helper.invoke_build()
+
+        assert result.exit_code == 0
+        with open(mkdocs_helper.test_dir / "site/index.html") as f:
+            soup = bs4.BeautifulSoup(f.read(), features="html.parser")
+
+    imgs = soup.find_all("img", attrs={"alt": "Kroki"})
+    assert len(imgs) == 2
+    light_imgs = [img for img in imgs if img["src"].endswith("#only-light")]
+    dark_imgs = [img for img in imgs if img["src"].endswith("#only-dark")]
+    assert len(light_imgs) == 1
+    assert len(dark_imgs) == 1
+
+
+@pytest.mark.usefixtures("kroki_dummy")
+def test_single_styles_still_renders_single_img() -> None:
+    """Existing single-styles behavior is unchanged."""
+    code_block = """```plantuml
+@startuml
+A -> B
+@enduml
+```"""
+    with MkDocsTemplateHelper(code_block) as mkdocs_helper:
+        mkdocs_helper.set_http_method("POST")
+        mkdocs_helper.set_tag_format("img")
+        mkdocs_helper.set_styles_light(_LIGHT_STYLES)
+        # Only light set, no dark → single image
+        result = mkdocs_helper.invoke_build()
+
+        assert result.exit_code == 0
+        with open(mkdocs_helper.test_dir / "site/index.html") as f:
+            soup = bs4.BeautifulSoup(f.read(), features="html.parser")
+
+    imgs = soup.find_all("img", attrs={"alt": "Kroki"})
+    assert len(imgs) == 1
+    assert "#only-light" not in imgs[0].get("src", "")
+    assert "#only-dark" not in imgs[0].get("src", "")
+
+
+@pytest.mark.usefixtures("kroki_dummy")
+def test_dual_styles_with_background_colors() -> None:
+    """Background color style attribute is applied to both img tags."""
+    code_block = """```plantuml
+@startuml
+A -> B
+@enduml
+```"""
+    with MkDocsTemplateHelper(code_block) as mkdocs_helper:
+        mkdocs_helper.set_http_method("POST")
+        mkdocs_helper.set_tag_format("img")
+        mkdocs_helper.set_styles_light(_LIGHT_STYLES)
+        mkdocs_helper.set_styles_dark(_DARK_STYLES)
+        mkdocs_helper.set_diagram_background_color_light("white")
+        mkdocs_helper.set_diagram_background_color_dark("#1e1e1e")
+        result = mkdocs_helper.invoke_build()
+
+        assert result.exit_code == 0
+        with open(mkdocs_helper.test_dir / "site/index.html") as f:
+            soup = bs4.BeautifulSoup(f.read(), features="html.parser")
+
+    imgs = soup.find_all("img", attrs={"alt": "Kroki"})
+    assert len(imgs) == 2
+    for img in imgs:
+        assert "light-dark(white, #1e1e1e)" in img.get("style", "")
+
+
+@pytest.mark.usefixtures("kroki_dummy")
+def test_no_dual_styles_when_not_configured() -> None:
+    """Without styles_light/styles_dark, no theme hash fragments are added."""
+    code_block = """```plantuml
+@startuml
+A -> B
+@enduml
+```"""
+    with MkDocsTemplateHelper(code_block) as mkdocs_helper:
+        mkdocs_helper.set_http_method("POST")
+        mkdocs_helper.set_tag_format("img")
+        result = mkdocs_helper.invoke_build()
+
+        assert result.exit_code == 0
+        with open(mkdocs_helper.test_dir / "site/index.html") as f:
+            content = f.read()
+
+    assert "#only-light" not in content
+    assert "#only-dark" not in content

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -60,6 +60,12 @@ class MkDocsHelper(AbstractContextManager):
         def set_diagram_background_color_dark(self, color: str) -> None:
             self._get_plugin_config_entry()["diagram_background_color_dark"] = color
 
+        def set_styles_light(self, styles: dict) -> None:
+            self._get_plugin_config_entry()["styles_light"] = styles
+
+        def set_styles_dark(self, styles: dict) -> None:
+            self._get_plugin_config_entry()["styles_dark"] = styles
+
         def invoke_build(self) -> Result:
             self._dump_config()
             runner = CliRunner()


### PR DESCRIPTION
## Summary

- Add `styles_light` and `styles_dark` config options for theme-aware diagram styling
- When both are set, the plugin renders **two versions** of each diagram and emits dual `<img>` tags with Material's `#only-light` / `#only-dark` hash fragments
- Material's CSS automatically shows the correct diagram based on the active color scheme

## How it works

The parser creates two `StyleInjector` instances (light and dark) and injects both style sets into separate copies of each diagram source. The renderer fetches both image URLs in parallel via `asyncio.gather` and produces:

```html
<img alt="Kroki" src="diagram-light.svg#only-light" style="..." />
<img alt="Kroki" src="diagram-dark.svg#only-dark" style="..." />
```

## Fallback behavior

- **Non-img tag formats** (`object`, `svg`): logs a warning and falls back to light-mode styles only
- **Only one of light/dark set**: uses that single injector without dual rendering (no hash fragments)
- **`styles` + `styles_light`/`styles_dark` both set**: `styles` is ignored with a warning log
- **`no-style-inject=true`**: skips injection for both light and dark

## Files changed

| File | Change |
|---|---|
| `kroki/common.py` | Add `data_dark` field to `KrokiImageContext` |
| `kroki/config.py` | Add `styles_light`/`styles_dark` options + validation warning |
| `kroki/parsing.py` | Dual style injection logic in `MarkdownParser` |
| `kroki/plugin.py` | Wire up light/dark `StyleInjector` instances |
| `kroki/render.py` | `_render_dual` and `_dual_image_response` methods |
| `tests/utils.py` | Add `set_styles_light`/`set_styles_dark` helpers |
| `tests/test_theme_styles.py` | 4 unit tests + 5 integration tests |
| `README.md` | Config table entries + Theme-Aware Styles docs section |
| `playground/mkdocs.yml` | Switch to Material theme with light/dark styles demo |

## Test plan

- [x] 4 unit tests verify parser dual injection, single injection, no-inject skip, and light-only behavior
- [x] 5 integration tests verify dual `<img>` rendering, hash fragments, single-style fallback, background colors, and no-dual when unconfigured
- [x] All 141 tests pass (132 existing + 9 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)