### PR TITLE
fix: Fence regex skips diagrams after code blocks with unrecognized attributes

### DIFF
--- a/kroki/parsing.py
+++ b/kroki/parsing.py
@@ -20,7 +20,7 @@ from kroki.styles import StyleInjector
 _FENCE_RE = re.compile(
     r"(?P<fence>^(?P<indent>[ ]*)(?:````*|~~~~*))[ ]*"
     r"(\.?(?P<lang>[\w#.+-]*)[ ]*)?"
-    r"(?P<opts>\{[^}]*\}|(?:[ ]?[a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_]+)*)\n"
+    r"(?P<opts>\{[^}]*\}|(?:[ ]?[a-zA-Z0-9\-_]+=[a-zA-Z0-9\-_]+)*)[^\n]*\n"
     r"(?P<code>.*?)(?<=\n)"
     r"(?P=fence)[ ]*$",
     flags=re.IGNORECASE + re.DOTALL + re.MULTILINE,

--- a/playground/docs/fence-after-code.md
+++ b/playground/docs/fence-after-code.md
@@ -1,0 +1,62 @@
+# Diagram After Code Snippet
+
+Regression test: a fenced code block with attributes (e.g. `title`) preceding a diagram
+must not prevent the diagram from being processed by the kroki plugin.
+
+## Example Code
+
+```python title="example/hello.py"
+import sys
+
+
+def greet(name: str) -> None:
+    print(f"Hello, {name}!")
+
+
+if __name__ == "__main__":
+    greet(sys.argv[1] if len(sys.argv) > 1 else "world")
+```
+
+## First Activity Diagram
+
+This diagram must be rendered by kroki with styles applied.
+
+```plantuml
+@startuml
+
+|User|
+start
+:Open the application;
+:Fill in the form;
+
+|System|
+:Validate input;
+:Store the record;
+
+stop
+
+@enduml
+```
+
+## Second Activity Diagram
+
+This diagram should also be rendered identically.
+
+```plantuml
+@startuml
+
+|System|
+start
+:Receive request;
+
+|Worker|
+:Process the task;
+:Return result;
+
+|System|
+:Send response;
+
+stop
+
+@enduml
+```

--- a/tests/test_fences.py
+++ b/tests/test_fences.py
@@ -259,6 +259,11 @@ bar
         expected_code_block_data="bar\n",
         expected_kroki_type="mermaid",
     ),
+}
+
+# example-146: tilde fences allow backticks in info strings per CommonMark spec,
+# so this is now correctly matched after the fence regex fix.
+TEST_CASES_NOT_COMPLYING_TILDE = {
     "https://spec.commonmark.org/0.31.2/#example-146": StubInput(
         page_data="""
 ~~~ mermaid ``` ~~~
@@ -274,7 +279,8 @@ foo
 @pytest.mark.parametrize(
     "test_data",
     [pytest.param(v, id=k) for k, v in TEST_CASES.items()]
-    + [pytest.param(v, id=k) for k, v in TEST_CASES_NOT_COMPLYING.items()],
+    + [pytest.param(v, id=k) for k, v in TEST_CASES_NOT_COMPLYING.items()]
+    + [pytest.param(v, id=k) for k, v in TEST_CASES_NOT_COMPLYING_TILDE.items()],
 )
 def test_fences(
     test_data: StubInput,
@@ -315,3 +321,36 @@ def test_fences_not_supported(
     parser.replace_kroki_blocks(test_data.page_data, callback_stub, context_stub)
     # Assert
     callback_stub.assert_not_called()
+
+
+def test_diagram_after_code_block_with_attributes(
+    mock_kroki_diagram_types: KrokiDiagramTypes,
+    mocker: MockerFixture,
+) -> None:
+    """A code block with unrecognized attributes (e.g. title) must not
+    consume the closing fence of a subsequent diagram block."""
+    page_data = """
+```python title="example/hello.py"
+print("hello")
+```
+
+```mermaid
+graph LR
+    A --> B
+```
+"""
+    parser = MarkdownParser("", mock_kroki_diagram_types)
+    callback_stub = AsyncMock(return_value="")
+    context_stub = mocker.stub()
+
+    parser.replace_kroki_blocks(page_data, callback_stub, context_stub)
+
+    callback_stub.assert_called_once_with(
+        KrokiImageContext(
+            kroki_type="mermaid",
+            options={},
+            plugin_options={},
+            data=Ok("graph LR\n    A --> B\n"),
+        ),
+        context_stub,
+    )


### PR DESCRIPTION
## Summary

- Fenced code blocks with attributes the regex cannot parse (e.g. `title="..."`) caused the closing fence to be mismatched with a subsequent diagram's closing fence, silently preventing that diagram from being processed by the kroki plugin
- Add `[^\n]*` before `\n` in the fence regex to consume unrecognized trailing content on the opening fence line, ensuring proper fence pairing
- Move CommonMark example-146 (tilde fence with backticks in info string) to supported test cases, as it is now correctly matched per the spec

## Reproduction

A page like this would cause the first plantuml diagram to be skipped:

````markdown
```python title="example/hello.py"
print("hello")
```

```plantuml
@startuml
Alice -> Bob
@enduml
```
````

The `title="..."` attribute contains characters (`"`, `~`, `/`, `.`) not matched by the options pattern. The regex failed to match the python block's opening fence but matched its closing `` ``` `` as a new opening fence, which then paired with the plantuml block's closing fence — consuming both as a single non-diagram match.

## Test plan

- [x] New regression test `test_diagram_after_code_block_with_attributes`
- [x] All 152 existing tests pass
- [x] New playground page `fence-after-code.md` for manual verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)